### PR TITLE
Add a util class which will help find fragment information in queries

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,6 +20,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    sourceSets {
+        main.java.srcDirs += 'src/main/java'
+        test.java.srcDirs += 'src/test/kotlin'
+    }
 }
 
 androidExtensions {

--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentRegexUtil.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentRegexUtil.kt
@@ -1,0 +1,21 @@
+package io.github.wax911.library.annotation.processor.fragment
+
+object FragmentRegexUtil {
+    // Allowed GraphQL names characters are documented here: https://graphql.github.io/graphql-spec/draft/#sec-Names
+    // We want to find all occurrences of "...SomeFragment". And the only piece we care about extracting is the
+    // name of the fragment ("SomeFragment", group(2) in the regex match result).
+    private const val REGEX_FRAGMENT_REFERENCE = "\\.\\.\\.(\\s+)?([_A-Za-z][_0-9A-Za-z]*)"
+    private const val GROUP_FRAGMENT_REFERENCE = 2
+
+    fun findFragmentReferences(query: String): Set<String> {
+        val fragmentRefMatches = REGEX_FRAGMENT_REFERENCE
+            .toRegex(setOf(RegexOption.MULTILINE, RegexOption.DOT_MATCHES_ALL))
+            .findAll(query)
+
+        return fragmentRefMatches.filter {
+            it.groupValues.size >= (GROUP_FRAGMENT_REFERENCE + 1)
+        }.map {
+            it.groupValues[GROUP_FRAGMENT_REFERENCE]
+        }.toSet()
+    }
+}

--- a/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/FragmentRegexUtilTest.kt
+++ b/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/FragmentRegexUtilTest.kt
@@ -1,0 +1,101 @@
+package io.github.wax911.library.annotation.processor.fragment
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FragmentRegexUtilTest {
+    private val fragmentNameA = "someObjectAFragment"
+    private val fragmentNameB = "someObjectBFragment"
+    private val fragmentNameC = "someObjectCFragment"
+    private val fragmentNameD = "_someObjectDFragment_123"
+
+    private val validFormatQuery = """
+        query SomeQuery {
+          someQuery {
+            id
+            name
+            someObjectA {
+              ...$fragmentNameA
+            }
+            someObjectB {
+              # With a space after ...
+              ... $fragmentNameB
+            }
+            someObjectC {
+              # With multiple spaces after ...
+              ...   $fragmentNameC
+            }
+            someObjectD {
+              # Non alpha chars in name ...
+              ... $fragmentNameD
+            }
+          }
+        }
+    """.trimIndent()
+
+    private val invalidFormatQuery = """
+        query SomeQuery {
+          someQuery {
+            id
+            name
+            someObjectA {
+              # Missing a dot (.)
+              ..$fragmentNameA
+            }
+            someObjectB {
+              # No dots
+              $fragmentNameB
+            }
+            someObjectC {
+              # Invalid fragment name character (!)
+              $fragmentNameC!
+            }
+          }
+        }
+    """.trimIndent()
+
+    // Some good formatting / some bad.
+    private val mixedFormatQuery = """
+        query SomeQuery {
+          someQuery {
+            id
+            name
+            someObjectA {
+              ...$fragmentNameA
+            }
+            someObjectB {
+              # With a space after ...
+              ... $fragmentNameB
+            }
+            someObjectC {
+              # No dots
+              $fragmentNameC
+            }
+            someObjectD {
+              # Invalid fragment name character (!)
+              $fragmentNameD!
+            }
+          }
+        }
+    """.trimIndent()
+
+    private val subj = FragmentRegexUtil
+
+    @Test
+    fun `Given all valid formatting in Query, When find fragment references, Then find all`() {
+        val expected = setOf(fragmentNameA, fragmentNameB, fragmentNameC, fragmentNameD)
+        assertEquals(expected, subj.findFragmentReferences(validFormatQuery))
+    }
+
+    @Test
+    fun `Given all invalid formatting in Query, When find fragment references, Then find nothing`() {
+        val expected = setOf<String>()
+        assertEquals(expected, subj.findFragmentReferences(invalidFormatQuery))
+    }
+
+    @Test
+    fun `Given mixed good and bad formatting in Query, When find fragment references, Then find only the good`() {
+        val expected = setOf(fragmentNameA, fragmentNameB)
+        assertEquals(expected, subj.findFragmentReferences(mixedFormatQuery))
+    }
+}


### PR DESCRIPTION
NOTE: This PR is being merged into a long running branch. Once this new feature has had all work merged into this branch, it will be ready to open up as a PR against the original author's github repo.



This is the first of several PRs that will allow GraphQL fragments to live in their own files, and be imported into queries that reference them. 

Just to start, I have introduced a new class with a regex utility that can find occurrences of `...Fragment`. I have also written tests for this new utility. 