### PR TITLE
Update fragment regex utility to find fragment definitions 

### DIFF
--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentRegexUtil.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentRegexUtil.kt
@@ -3,19 +3,32 @@ package io.github.wax911.library.annotation.processor.fragment
 object FragmentRegexUtil {
     // Allowed GraphQL names characters are documented here: https://graphql.github.io/graphql-spec/draft/#sec-Names
     // We want to find all occurrences of "...SomeFragment". And the only piece we care about extracting is the
-    // name of the fragment ("SomeFragment", group(2) in the regex match result).
-    private const val REGEX_FRAGMENT_REFERENCE = "\\.\\.\\.(\\s+)?([_A-Za-z][_0-9A-Za-z]*)"
+    // name of the fragment ("SomeFragment")
+    private const val REGEX_FRAGMENT_NAME = "[_A-Za-z][_0-9A-Za-z]*"
+    private const val REGEX_FRAGMENT_REFERENCE = "\\.\\.\\.(\\s+)?($REGEX_FRAGMENT_NAME)"
+    private const val REGEX_FRAGMENT_DEFINITION = "fragment\\s{1,}([_A-Za-z][_0-9A-Za-z]*)\\s{1,}on"
+    // The fragment name will be found in group 2 of the reference regex match result.
     private const val GROUP_FRAGMENT_REFERENCE = 2
+    // The fragment name will be found in group 1 of the definition regex match result.
+    private const val GROUP_FRAGMENT_DEFINITION = 1
 
     fun findFragmentReferences(query: String): Set<String> {
-        val fragmentRefMatches = REGEX_FRAGMENT_REFERENCE
+        return extractFragmentNames(query, REGEX_FRAGMENT_REFERENCE, GROUP_FRAGMENT_REFERENCE)
+    }
+
+    fun findFragmentDefinitions(query: String): Set<String> {
+        return extractFragmentNames(query, REGEX_FRAGMENT_DEFINITION, GROUP_FRAGMENT_DEFINITION)
+    }
+
+    private fun extractFragmentNames(query: String, regexStr: String, groupIndex: Int): Set<String> {
+        val regexMatches = regexStr
             .toRegex(setOf(RegexOption.MULTILINE, RegexOption.DOT_MATCHES_ALL))
             .findAll(query)
 
-        return fragmentRefMatches.filter {
-            it.groupValues.size >= (GROUP_FRAGMENT_REFERENCE + 1)
+        return regexMatches.filter {
+            it.groupValues.size >= (groupIndex + 1)
         }.map {
-            it.groupValues[GROUP_FRAGMENT_REFERENCE]
+            it.groupValues[groupIndex]
         }.toSet()
     }
 }


### PR DESCRIPTION
NOTE: This PR is being merged into a long running branch. Once this new feature has had all work merged into this branch, it will be ready to open up as a PR against the original author's github repo.

This is the second of several PRs that will allow GraphQL fragments to live in their own files, and be imported into queries that reference them. We are contributing this feature to this open source project, primarily because it's missing, and we will want it.

This PR updates the `FragmentRegexUtil` to be able to extract fragment _definitions_. This is different than the last PR, which added the ability to extract fragment references. This will be used to determine whether a .graphql file is missing inline fragment definitions, and the code should look to a `Fragment` folder to try and find them.