### PR TITLE
Adds a class that can produce an analysis report of fragment referenc…

### DIFF
--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentAnalysis.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentAnalysis.kt
@@ -1,0 +1,6 @@
+package io.github.wax911.library.annotation.processor.fragment
+
+/**
+ * A simple data class that defines a fragment reference (by name), and whether or not it was defined with some query.
+ */
+data class FragmentAnalysis(val fragmentReference: String, val isDefined: Boolean)

--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentAnalyzer.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentAnalyzer.kt
@@ -1,0 +1,9 @@
+package io.github.wax911.library.annotation.processor.fragment
+
+/**
+ * A contract for something that can parse a query and provide a full analysis of what fragments are referenced, and
+ * whether the fragments are defined with the query.
+ */
+interface FragmentAnalyzer {
+    fun analyzeFragments(query: String): Set<FragmentAnalysis>
+}

--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentRegexUtil.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentRegexUtil.kt
@@ -1,5 +1,10 @@
 package io.github.wax911.library.annotation.processor.fragment
 
+/**
+ * This util class provides helpful methods for finding fragment information in a GraphQL query. It has a method for
+ * finding all references to fragments within a query. And another method for finding all defined fragments, which may
+ * exist after the query.
+ */
 object FragmentRegexUtil {
     // Allowed GraphQL names characters are documented here: https://graphql.github.io/graphql-spec/draft/#sec-Names
     // We want to find all occurrences of "...SomeFragment". And the only piece we care about extracting is the
@@ -12,14 +17,26 @@ object FragmentRegexUtil {
     // The fragment name will be found in group 1 of the definition regex match result.
     private const val GROUP_FRAGMENT_DEFINITION = 1
 
+    /**
+     * Finds all distinct references to fragments in a query. A set of all unique fragment names (which are the
+     * references) is returned.
+     */
     fun findFragmentReferences(query: String): Set<String> {
         return extractFragmentNames(query, REGEX_FRAGMENT_REFERENCE, GROUP_FRAGMENT_REFERENCE)
     }
 
+    /**
+     * Finds all defined fragments, which are usually found after a query. A set of all unique fragment names is
+     * returned.
+     */
     fun findFragmentDefinitions(query: String): Set<String> {
         return extractFragmentNames(query, REGEX_FRAGMENT_DEFINITION, GROUP_FRAGMENT_DEFINITION)
     }
 
+    /**
+     * Finds all strings defined by "regexStr" in the provided "query". The regex might return multiple match groups,
+     * so the "groupIndex" indicating the position of the expecting string should be specified.
+     */
     private fun extractFragmentNames(query: String, regexStr: String, groupIndex: Int): Set<String> {
         val regexMatches = regexStr
             .toRegex(setOf(RegexOption.MULTILINE, RegexOption.DOT_MATCHES_ALL))

--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/RegexFragmentAnalyzer.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/RegexFragmentAnalyzer.kt
@@ -1,0 +1,16 @@
+package io.github.wax911.library.annotation.processor.fragment
+
+/**
+ * An implementation of FragmentAnalyzer that simply uses regular expressions to find fragment references, and whether
+ * they are defined with the query.
+ */
+class RegexFragmentAnalyzer : FragmentAnalyzer {
+    override fun analyzeFragments(query: String): Set<FragmentAnalysis> {
+        val fragmentReferences = FragmentRegexUtil.findFragmentReferences(query)
+        val fragmentDefinitions = FragmentRegexUtil.findFragmentDefinitions(query)
+
+        return fragmentReferences.map {
+            FragmentAnalysis(fragmentReference = it, isDefined = fragmentDefinitions.contains(it))
+        }.toSet()
+    }
+}

--- a/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/RegexFragmentAnalyzerSpec.kt
+++ b/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/RegexFragmentAnalyzerSpec.kt
@@ -1,0 +1,117 @@
+package io.github.wax911.library.annotation.processor.fragment
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RegexFragmentAnalyzerSpec {
+    private val fragmentNameTemplate = "someObject%sFragment"
+    private val typeTemplate = "Object%s"
+    private val fragmentA = createFragmentName("A")
+    private val fragmentB = createFragmentName("B")
+    private val fragmentC = createFragmentName("C")
+    private val fragmentD = createFragmentName("D")
+    private val typeA = createType("A")
+    private val typeB = createType("B")
+    private val typeC = createType("C")
+    private val typeD = createType("D")
+
+    private val fragmentTemplate = """
+        fragment %s on %s {
+          id
+          name
+          %s
+        }
+    """.trimIndent()
+
+    private val queryTemplate = """
+        query SomeQuery {
+          someQuery {
+            objectA {
+              ...$fragmentA
+            }
+            objectB {
+              ...$fragmentB
+            }
+            objectC {
+              ...$fragmentC
+            }
+          }
+        }
+
+        %s
+    """.trimIndent()
+
+    private val subj = RegexFragmentAnalyzer()
+
+    @Test
+    fun `Given a query with all fragments defined, When analyze fragments, Then analysis matches expectation`() {
+        val expected = setOf(
+            FragmentAnalysis(fragmentA, true),
+            FragmentAnalysis(fragmentB, true),
+            FragmentAnalysis(fragmentC, true)
+        )
+
+        val definedFragments = """
+            ${createFragment(fragmentA, typeA)}
+
+            ${createFragment(fragmentB, typeB)}
+
+            ${createFragment(fragmentC, typeC)}
+        """.trimIndent()
+
+        assertEquals(expected, subj.analyzeFragments(createQuery(definedFragments)))
+    }
+
+    @Test
+    fun `Given a query with 1 of 3 fragments defined, When analyze fragments, Then analysis matches expectation`() {
+        val expected = setOf(
+            FragmentAnalysis(fragmentA, true),
+            FragmentAnalysis(fragmentB, false),
+            FragmentAnalysis(fragmentC, false),
+            FragmentAnalysis(fragmentD, true)
+        )
+
+        val definedFragments = """
+            ${createFragment(fragmentA, typeA, "...$fragmentD")}
+            ${createFragment(fragmentD, typeD)}
+        """.trimIndent()
+
+        println(definedFragments)
+
+        assertEquals(expected, subj.analyzeFragments(createQuery(definedFragments)))
+    }
+
+    @Test
+    fun `Given a query with no fragments defined, When analyze fragments, Then analysis matches expectation`() {
+        val expected = setOf(
+            FragmentAnalysis(fragmentA, false),
+            FragmentAnalysis(fragmentB, false),
+            FragmentAnalysis(fragmentC, false)
+        )
+
+        assertEquals(expected, subj.analyzeFragments(createQuery()))
+    }
+
+    @Test
+    fun `Given a query with fragments within fragments, When analyze fragments, Then analysis matches expectation`() {
+        val expected = setOf(
+            FragmentAnalysis(fragmentA, false),
+            FragmentAnalysis(fragmentB, false),
+            FragmentAnalysis(fragmentC, false)
+        )
+
+        assertEquals(expected, subj.analyzeFragments(createQuery()))
+    }
+
+    private fun createQuery(definedFragments: String = ""): String {
+        return queryTemplate.format(definedFragments)
+    }
+
+    private fun createFragment(name: String, type: String, innerFragmentRef: String = ""): String {
+        return fragmentTemplate.format(name, type, innerFragmentRef)
+    }
+
+    private fun createFragmentName(letter: String) = fragmentNameTemplate.format(letter)
+
+    private fun createType(letter: String) = typeTemplate.format(letter)
+}


### PR DESCRIPTION
NOTE: This PR is being merged into a long running branch. Once this new feature has had all work merged into this branch, it will be ready to open up as a PR against the original author's github repo.

This PR adds a new set of classes which make it easy to analyze a query to see what fragment references exist, and also whether those fragments are defined with the query.

The `FragmentAnalysis` class describes a found fragment reference within a query, and whether its definition can also be found with the query.

The `RegexFragmentAnalyzer` uses regular expressions to analyze a query in order to produce a `Set` of the `FragmentAnalysis` classes.

This PR also adds some documentation to classes related to this logic.