### PR TITLE
Add a class that can piece together fragment Strings to be appended to a query

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ buildscript {
         httpLogger = '3.11.0'
 
         junit = '4.12'
+        mockk = '1.9'
         runner = '1.1.0'
         espresso = '3.1.0'
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,6 +25,10 @@ android {
         main.java.srcDirs += 'src/main/java'
         test.java.srcDirs += 'src/test/kotlin'
     }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 androidExtensions {
@@ -42,6 +46,7 @@ dependencies {
     implementation "com.squareup.retrofit2:converter-gson:$retrofit"
 
     testImplementation "junit:junit:$junit"
+    testImplementation "io.mockk:mockk:$mockk"
     androidTestImplementation "androidx.test:runner:$runner"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espresso"
 }

--- a/library/src/main/java/io/github/wax911/library/annotation/processor/GraphProcessor.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/GraphProcessor.kt
@@ -66,10 +66,10 @@ class GraphProcessor private constructor(assetManager: AssetManager?) {
                 paths?.also {
                     for (item in it) {
                         val absolute = "$path/$item"
-                        if (!item.endsWith(defaultExtension))
-                            createGraphQLMap(absolute, this)
-                        else
+                        if (item.endsWith(defaultExtension))
                             _graphFiles[item] = getFileContents(open(absolute))
+                        else
+                            createGraphQLMap(absolute, this)
                     }
                 }
             }

--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentAnalysis.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentAnalysis.kt
@@ -1,6 +1,7 @@
 package io.github.wax911.library.annotation.processor.fragment
 
 /**
- * A simple data class that defines a fragment reference (by name), and whether or not it was defined with some query.
+ * A simple data class that defines a fragment reference (by name), and whether or not it was defined with some graphql
+ * content.
  */
 data class FragmentAnalysis(val fragmentReference: String, val isDefined: Boolean)

--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentAnalyzer.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentAnalyzer.kt
@@ -1,9 +1,9 @@
 package io.github.wax911.library.annotation.processor.fragment
 
 /**
- * A contract for something that can parse a query and provide a full analysis of what fragments are referenced, and
- * whether the fragments are defined with the query.
+ * A contract for something that can parse graphql content and provide a full analysis of what fragments are referenced,
+ * and whether the fragments are defined with the query.
  */
 interface FragmentAnalyzer {
-    fun analyzeFragments(query: String): Set<FragmentAnalysis>
+    fun analyzeFragments(graphqlContent: String): Set<FragmentAnalysis>
 }

--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentPatcher.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentPatcher.kt
@@ -1,0 +1,58 @@
+package io.github.wax911.library.annotation.processor.fragment
+
+import android.util.Log
+
+/**
+ * This class will return a String containing fragment definitions. This String can be appended to a query in order to
+ * have all referenced fragments fully defined, before sending it to the server. This allows a query (for example) to
+ * reference fragments, but have the definition of those fragments live outside of the query file.
+ *
+ * This class also properly handles recursion. This means fragments can have references to other fragments, and it will
+ * do its best to resolve everything correctly.
+ */
+class FragmentPatcher(
+    private val defaultExtension: String,
+    private val fragmentAnalyzer: FragmentAnalyzer = RegexFragmentAnalyzer()
+) {
+    fun includeMissingFragments(
+        graphFile: String,
+        graphContent: String,
+        availableGraphFiles: Map<String, String>,
+        aggregation: StringBuilder = StringBuilder()
+    ): String {
+        // Look for any missing fragment definitions in the current graph content.
+        val missingFragments = fragmentAnalyzer.analyzeFragments(graphContent).filter { !it.isDefined }
+
+        if (missingFragments.isEmpty()) {
+            // Nothing to do. We can short circuit and return early.
+            return aggregation.toString()
+        }
+
+        // There is at least one missing fragment definition. It may be defined in its own file though. We will do
+        // our best to find and include it.
+        val count = missingFragments.count()
+        Log.d(TAG, "$count missing fragments in $graphFile. Attempting to find them elsewhere.")
+
+        missingFragments.forEach { missingFragment ->
+            val includeFile = "${missingFragment.fragmentReference}$defaultExtension"
+            val includeGraphContent = availableGraphFiles[includeFile]
+
+            if (includeGraphContent != null) {
+                // Found it! It, too, may have fragment references. So we need to recursively check it.
+                includeMissingFragments(includeFile, includeGraphContent, availableGraphFiles, aggregation)
+
+                // Now we can append this fragment's content.
+                aggregation.append("\n\n$includeGraphContent")
+            } else {
+                // This fragment is nowhere to be found.
+                Log.e(TAG, "$graphFile references $missingFragment, but it could not be located.")
+            }
+        }
+
+        return aggregation.toString()
+    }
+
+    companion object {
+        private val TAG = FragmentPatcher::class.simpleName
+    }
+}

--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentRegexUtil.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentRegexUtil.kt
@@ -2,8 +2,8 @@ package io.github.wax911.library.annotation.processor.fragment
 
 /**
  * This util class provides helpful methods for finding fragment information in a GraphQL query. It has a method for
- * finding all references to fragments within a query. And another method for finding all defined fragments, which may
- * exist after the query.
+ * finding all references to fragments within a graphql string. And another method for finding all defined fragments,
+ * which may exist after a query.
  */
 object FragmentRegexUtil {
     // Allowed GraphQL names characters are documented here: https://graphql.github.io/graphql-spec/draft/#sec-Names
@@ -18,29 +18,29 @@ object FragmentRegexUtil {
     private const val GROUP_FRAGMENT_DEFINITION = 1
 
     /**
-     * Finds all distinct references to fragments in a query. A set of all unique fragment names (which are the
-     * references) is returned.
+     * Finds all distinct references to fragments in some graphql string. A set of all unique fragment names
+     * (which are the references) is returned.
      */
-    fun findFragmentReferences(query: String): Set<String> {
-        return extractFragmentNames(query, REGEX_FRAGMENT_REFERENCE, GROUP_FRAGMENT_REFERENCE)
+    fun findFragmentReferences(graphqlContent: String): Set<String> {
+        return extractFragmentNames(graphqlContent, REGEX_FRAGMENT_REFERENCE, GROUP_FRAGMENT_REFERENCE)
     }
 
     /**
      * Finds all defined fragments, which are usually found after a query. A set of all unique fragment names is
      * returned.
      */
-    fun findFragmentDefinitions(query: String): Set<String> {
-        return extractFragmentNames(query, REGEX_FRAGMENT_DEFINITION, GROUP_FRAGMENT_DEFINITION)
+    fun findFragmentDefinitions(graphqlContent: String): Set<String> {
+        return extractFragmentNames(graphqlContent, REGEX_FRAGMENT_DEFINITION, GROUP_FRAGMENT_DEFINITION)
     }
 
     /**
-     * Finds all strings defined by "regexStr" in the provided "query". The regex might return multiple match groups,
-     * so the "groupIndex" indicating the position of the expecting string should be specified.
+     * Finds all strings defined by "regexStr" in the provided "graphqlContent". The regex will return multiple match
+     * groups, so the "groupIndex" indicating the position of the expecting string should be specified.
      */
-    private fun extractFragmentNames(query: String, regexStr: String, groupIndex: Int): Set<String> {
+    private fun extractFragmentNames(graphqlContent: String, regexStr: String, groupIndex: Int): Set<String> {
         val regexMatches = regexStr
             .toRegex(setOf(RegexOption.MULTILINE, RegexOption.DOT_MATCHES_ALL))
-            .findAll(query)
+            .findAll(graphqlContent)
 
         return regexMatches.filter {
             it.groupValues.size >= (groupIndex + 1)

--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/RegexFragmentAnalyzer.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/RegexFragmentAnalyzer.kt
@@ -5,9 +5,9 @@ package io.github.wax911.library.annotation.processor.fragment
  * they are defined with the query.
  */
 class RegexFragmentAnalyzer : FragmentAnalyzer {
-    override fun analyzeFragments(query: String): Set<FragmentAnalysis> {
-        val fragmentReferences = FragmentRegexUtil.findFragmentReferences(query)
-        val fragmentDefinitions = FragmentRegexUtil.findFragmentDefinitions(query)
+    override fun analyzeFragments(graphqlContent: String): Set<FragmentAnalysis> {
+        val fragmentReferences = FragmentRegexUtil.findFragmentReferences(graphqlContent)
+        val fragmentDefinitions = FragmentRegexUtil.findFragmentDefinitions(graphqlContent)
 
         return fragmentReferences.map {
             FragmentAnalysis(fragmentReference = it, isDefined = fragmentDefinitions.contains(it))

--- a/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/FragmentPatcherTest.kt
+++ b/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/FragmentPatcherTest.kt
@@ -1,0 +1,219 @@
+package io.github.wax911.library.annotation.processor.fragment
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FragmentPatcherTest {
+    private val defaultExtension = ".graphql"
+    private val mockFragmentAnalyzer = mockk<FragmentAnalyzer>()
+
+    private val graphFile = "SomeQuery.graphql"
+    private val graphContent = "%s: actual content doesn't matter for tests in this class"
+    private val fragmentA = "fragmentA"
+    private val fragmentB = "fragmentB"
+    private val fragmentC = "fragmentC"
+
+    private val subj = FragmentPatcher(defaultExtension, mockFragmentAnalyzer)
+
+    /**
+     * Tests this scenario:
+     *
+     * query SomeQuery {
+     *   someObjectA {
+     *     ...fragmentA
+     *   }
+     *   someObjectB {
+     *     ...fragmentB
+     *   }
+     * }
+     *
+     * fragment fragmentA on SomeObjectA {
+     *   id
+     * }
+     *
+     * fragment fragmentB on SomeObjectB {
+     *   id
+     * }
+     *
+     * # (All fragment definitions live in the query file)
+     */
+    @Test
+    fun `Given no missing fragment definitions, When include missing fragments, Then return empty string`() {
+        val analysis = analysis(mapOf(fragmentA to true, fragmentB to true))
+        val graphFiles = mapOf(graphFile to fakeContent(graphFile).first())
+
+        every { mockFragmentAnalyzer.analyzeFragments(any()) }.returns(analysis)
+
+        assertEquals("", subj.includeMissingFragments(graphFile, graphContent, graphFiles))
+    }
+
+    /**
+     * Tests this scenario:
+     *
+     * query SomeQuery {
+     *   someObjectA {
+     *     ...fragmentA
+     *   }
+     * }
+     *
+     * # (fragmentA not defined with query, but was found in the Fragment folder)
+     */
+    @Test
+    fun `Given a missing fragment definition, When include missing fragments, Then return missing contents`() {
+        val analysis = analysis(mapOf(fragmentA to false))
+
+        val (fragmentAKey) = file(fragmentA)
+
+        val (queryContent, fragmentAContent) = fakeContent(graphContent, fragmentA)
+
+        val graphFiles = mapOf(graphFile to queryContent, fragmentAKey to fragmentAContent)
+
+        every { mockFragmentAnalyzer.analyzeFragments(any()) }.returns(emptySet())
+        every { mockFragmentAnalyzer.analyzeFragments(queryContent) }.returns(analysis)
+
+        assertTrue(subj.includeMissingFragments(graphFile, queryContent, graphFiles).contains(fragmentAContent))
+    }
+
+    /**
+     * Tests this scenario:
+     *
+     * query SomeQuery {
+     *   someObjectA {
+     *     ...fragmentA
+     *   }
+     *   someObjectB {
+     *     ...fragmentB
+     *   }
+     *   someObjectC {
+     *     ...fragmentC
+     *   }
+     * }
+     *
+     * fragment fragmentC on SomeObjectC {
+     *   id
+     * }
+     *
+     * # (fragmentA and fragmentB not defined with query, but fragmentC is. fragmentA and fragmentB are found in the
+     * #  Fragment folder)
+     */
+    @Test
+    fun `Given multiple missing fragment definitions, When include missing fragments, Then return all missing contents`() {
+        val analysis = analysis(mapOf(fragmentA to false, fragmentB to false, fragmentC to true))
+
+        val (fragmentAKey, fragmentBKey, fragmentCKey) = file(fragmentA, fragmentB, fragmentC)
+
+        val (queryContent, fragmentAContent, fragmentBContent, fragmentCContent) =
+            fakeContent(graphFile, fragmentA, fragmentB, fragmentC)
+
+        val graphFiles = mapOf(
+            graphFile to queryContent,
+            fragmentAKey to fragmentAContent,
+            fragmentBKey to fragmentBContent,
+            fragmentCKey to fragmentCContent
+        )
+
+        every { mockFragmentAnalyzer.analyzeFragments(any()) }.returns(emptySet())
+        every { mockFragmentAnalyzer.analyzeFragments(queryContent) }.returns(analysis)
+
+        val result = subj.includeMissingFragments(graphFile, queryContent, graphFiles)
+
+        assertTrue(result.contains(fragmentAContent))
+        assertTrue(result.contains(fragmentBContent))
+        assertFalse(result.contains(fragmentCContent))
+    }
+
+    /**
+     * Tests this scenario:
+     *
+     * query SomeQuery {
+     *   someObjectA {
+     *     ...fragmentA
+     *   }
+     * }
+     *
+     * # (fragmentA not defined with query, and also does not exist in the Fragment folder)
+     */
+    @Test
+    fun `Given a fragment missing and not in map, When include missing fragments, Then return nothing`() {
+        val analysis = analysis(mapOf(fragmentA to false))
+
+        val (queryContent) = fakeContent(graphContent)
+
+        val graphFiles = emptyMap<String, String>()
+
+        every { mockFragmentAnalyzer.analyzeFragments(any()) }.returns(analysis)
+
+        assertTrue(subj.includeMissingFragments(graphFile, queryContent, graphFiles).isEmpty())
+    }
+
+    /**
+     * Tests this scenario:
+     *
+     * query SomeQuery {
+     *   someObjectA {
+     *     ...fragmentA
+     *   }
+     * }
+     *
+     * fragment fragmentA on SomeObjectA {
+     *   id
+     *   someObjectB {
+     *     ...fragmentB
+     *   }
+     * }
+     *
+     * # ----------------------------
+     * # Fragment/fragmentB.graphql
+     * fragment fragmentB on SomeObjectB {
+     *   id
+     *   someObjectC {
+     *     ...fragmentC
+     *   }
+     * }
+     *
+     * # ----------------------------
+     * # Fragment/fragmentC.graphql
+     * fragment fragmentC on SomeObjectC {
+     *   id
+     * }
+     *
+     * # (fragmentA is defined with the query. fragmentA references fragmentB which is NOT defined with the query, but
+     * #  is in the Fragment folder. fragmentB references fragmentC, which is also in the Fragment folder.)
+     */
+    @Test
+    fun `Given missing fragments and recursive references, When include missing fragments, Then return all missing contents`() {
+        val queryAnalysis = analysis(mapOf(fragmentA to true, fragmentB to false))
+        val fragmentBAnalysis = analysis(mapOf(fragmentC to false))
+
+        val (fragmentAKey, fragmentBKey, fragmentCKey) = file(fragmentA, fragmentB, fragmentC)
+
+        val (queryContent, fragmentAContent, fragmentBContent, fragmentCContent) =
+            fakeContent(graphFile, fragmentA, fragmentB, fragmentC)
+
+        val graphFiles = mapOf(
+            graphFile to queryContent,
+            fragmentAKey to fragmentAContent,
+            fragmentBKey to fragmentBContent,
+            fragmentCKey to fragmentCContent
+        )
+
+        every { mockFragmentAnalyzer.analyzeFragments(any()) }.returns(emptySet())
+        every { mockFragmentAnalyzer.analyzeFragments(queryContent) }.returns(queryAnalysis)
+        every { mockFragmentAnalyzer.analyzeFragments(fragmentBContent) }.returns(fragmentBAnalysis)
+
+        val result = subj.includeMissingFragments(graphFile, queryContent, graphFiles)
+
+        assertTrue(result.contains(fragmentBContent))
+        assertTrue(result.contains(fragmentCContent))
+    }
+
+    private fun file(vararg name: String) = name.map { "$it$defaultExtension" }.toList()
+
+    private fun analysis(map: Map<String, Boolean>) = map.map { FragmentAnalysis(it.key, it.value) }.toSet()
+
+    private fun fakeContent(vararg identifier: String) = identifier.map { graphContent.format(it) }.toList()
+}

--- a/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/RegexFragmentAnalyzerTest.kt
+++ b/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/RegexFragmentAnalyzerTest.kt
@@ -3,7 +3,7 @@ package io.github.wax911.library.annotation.processor.fragment
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-class RegexFragmentAnalyzerSpec {
+class RegexFragmentAnalyzerTest {
     private val fragmentNameTemplate = "someObject%sFragment"
     private val typeTemplate = "Object%s"
     private val fragmentA = createFragmentName("A")
@@ -67,16 +67,12 @@ class RegexFragmentAnalyzerSpec {
         val expected = setOf(
             FragmentAnalysis(fragmentA, true),
             FragmentAnalysis(fragmentB, false),
-            FragmentAnalysis(fragmentC, false),
-            FragmentAnalysis(fragmentD, true)
+            FragmentAnalysis(fragmentC, false)
         )
 
         val definedFragments = """
-            ${createFragment(fragmentA, typeA, "...$fragmentD")}
-            ${createFragment(fragmentD, typeD)}
+            ${createFragment(fragmentA, typeA)}
         """.trimIndent()
-
-        println(definedFragments)
 
         assertEquals(expected, subj.analyzeFragments(createQuery(definedFragments)))
     }
@@ -95,15 +91,22 @@ class RegexFragmentAnalyzerSpec {
     @Test
     fun `Given a query with fragments within fragments, When analyze fragments, Then analysis matches expectation`() {
         val expected = setOf(
-            FragmentAnalysis(fragmentA, false),
+            FragmentAnalysis(fragmentA, true),
             FragmentAnalysis(fragmentB, false),
-            FragmentAnalysis(fragmentC, false)
+            FragmentAnalysis(fragmentC, false),
+            FragmentAnalysis(fragmentD, true)
         )
 
-        assertEquals(expected, subj.analyzeFragments(createQuery()))
+        val definedFragments = """
+            ${createFragment(fragmentA, typeA, "...$fragmentD")}
+            ${createFragment(fragmentD, typeD)}
+        """.trimIndent()
+
+        assertEquals(expected, subj.analyzeFragments(createQuery(definedFragments)))
     }
 
     private fun createQuery(definedFragments: String = ""): String {
+        println(queryTemplate.format(definedFragments))
         return queryTemplate.format(definedFragments)
     }
 


### PR DESCRIPTION
NOTE: This PR is being merged into a long running branch. Once this new feature has had all work merged into this branch, it will be ready to open up as a PR against the original author's github repo. More details here: https://github.com/AniTrend/retrofit-graphql/issues/9

This PR focuses on providing a way to append together fragment Strings into one String that can then be tacked onto the query String. It uses the previously introduced code (by us) to analyze a GraphQL query, by looking for fragment references and their definitions. When a query references fragments, those fragments must be defined somewhere. They can either be defined below the query. Or (what we are adding support for), they can be externally defined (in a separate file).

So logic is needed to be able to pull those externally defined fragments, and append them together. This can then be tacked onto the bottom of the query, thus making sure all fragment references have definitions before sending the query to the server.

There's _lots_ of comments and test code in this. I believe the comments should help to further explain things.

