### PR TITLE
Wire up the new fragment patching logic to the GraphProcessor

### DIFF
--- a/app/src/main/assets/graphql/Example/Fragment/RepositoryFragment.graphql
+++ b/app/src/main/assets/graphql/Example/Fragment/RepositoryFragment.graphql
@@ -1,0 +1,8 @@
+fragment RepositoryFragment on Repository {
+  name
+  full_name
+  owner {
+    ...UserFragment
+  }
+  stargazers_count
+}

--- a/app/src/main/assets/graphql/Example/Fragment/UserFragment.graphql
+++ b/app/src/main/assets/graphql/Example/Fragment/UserFragment.graphql
@@ -1,0 +1,5 @@
+fragment UserFragment on User {
+  login
+  avatar_url
+  html_url
+}

--- a/app/src/main/assets/graphql/Example/Fragment/VoteFragment.graphql
+++ b/app/src/main/assets/graphql/Example/Fragment/VoteFragment.graphql
@@ -1,0 +1,3 @@
+fragment VoteFragment on Vote {
+	vote_value
+}

--- a/app/src/main/assets/graphql/Example/Query/RepoEntries.graphql
+++ b/app/src/main/assets/graphql/Example/Query/RepoEntries.graphql
@@ -2,33 +2,14 @@ query RepoEntries($repoFullName: String!) {
   entry(repoFullName: $repoFullName) {
     id
 	repository {
-		...repository
+		...RepositoryFragment
 	}
 	postedBy {
-		...user
+		...UserFragment
 	}
 	vote {
-		...vote
+		...VoteFragment
 	}
 	score
   }
-}
-
-fragment repository on Repository {
-  name
-  full_name
-  owner {
-    ...user
-  }
-  stargazers_count
-}
-
-fragment user on User {
-  login
-  avatar_url
-  html_url
-}
-
-fragment vote on Vote {
-	vote_value
 }

--- a/app/src/main/assets/graphql/Example/Query/Trending.graphql
+++ b/app/src/main/assets/graphql/Example/Query/Trending.graphql
@@ -3,25 +3,11 @@ query Trending($type: FeedType!, $offset: Int, $limit: Int) {
     id
     hotScore
     repository {
-      ...repository
+      ...RepositoryFragment
     }
     postedBy {
-      ...user
+      ...UserFragment
     }
   }
 }
 
-fragment repository on Repository {
-  name
-  full_name
-  owner {
-    ...user
-  }
-  stargazers_count
-}
-
-fragment user on User {
-  login
-  avatar_url
-  html_url
-}

--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentPatcher.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentPatcher.kt
@@ -42,17 +42,22 @@ class FragmentPatcher(
                 includeMissingFragments(includeFile, includeGraphContent, availableGraphFiles, aggregation)
 
                 // Now we can append this fragment's content.
-                aggregation.append("\n\n$includeGraphContent")
+                val isNew = !aggregation.contains(includeGraphContent.toRegex(RegexOption.LITERAL))
+                if (isNew) {
+                    aggregation.append("\n\n$includeGraphContent")
+                }
             } else {
                 // This fragment is nowhere to be found.
                 Log.e(TAG, "$graphFile references $missingFragment, but it could not be located.")
             }
         }
 
+        Log.d(TAG, "Patch produced for: $graphFile\n$aggregation")
+
         return aggregation.toString()
     }
 
     companion object {
-        private val TAG = FragmentPatcher::class.simpleName
+        private const val TAG = "FragmentPatcher"
     }
 }

--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/RegexFragmentAnalyzer.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/RegexFragmentAnalyzer.kt
@@ -6,8 +6,8 @@ package io.github.wax911.library.annotation.processor.fragment
  */
 class RegexFragmentAnalyzer : FragmentAnalyzer {
     override fun analyzeFragments(graphqlContent: String): Set<FragmentAnalysis> {
-        val fragmentReferences = FragmentRegexUtil.findFragmentReferences(graphqlContent)
-        val fragmentDefinitions = FragmentRegexUtil.findFragmentDefinitions(graphqlContent)
+        val fragmentReferences = GraphRegexUtil.findFragmentReferences(graphqlContent)
+        val fragmentDefinitions = GraphRegexUtil.findFragmentDefinitions(graphqlContent)
 
         return fragmentReferences.map {
             FragmentAnalysis(fragmentReference = it, isDefined = fragmentDefinitions.contains(it))

--- a/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/GraphRegexUtilTest.kt
+++ b/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/GraphRegexUtilTest.kt
@@ -1,9 +1,11 @@
 package io.github.wax911.library.annotation.processor.fragment
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class FragmentRegexUtilTest {
+class GraphRegexUtilTest {
     private val fragmentNameA = "someObjectAFragment"
     private val fragmentNameB = "someObjectBFragment"
     private val fragmentNameC = "someObjectCFragment"
@@ -158,7 +160,7 @@ class FragmentRegexUtilTest {
         }
     """.trimIndent()
 
-    private val subj = FragmentRegexUtil
+    private val subj = GraphRegexUtil
 
     @Test
     fun `Given all valid formatting in Query, When find fragment references, Then find all`() {
@@ -194,5 +196,15 @@ class FragmentRegexUtilTest {
     fun `Given mixed good and bad formatting in Query, When find fragment definitions, Then find only the good`() {
         val expected = setOf(fragmentNameA, fragmentNameB)
         assertEquals(expected, subj.findFragmentDefinitions(mixedFormatQuery))
+    }
+
+    @Test
+    fun `Given a Query, When contains a query, Then return true`() {
+        assertTrue(subj.containsAQuery(validFormatQuery))
+    }
+
+    @Test
+    fun `Given not a Query, When contains a query, Then return false`() {
+        assertFalse(subj.containsAQuery(fragmentNameA))
     }
 }


### PR DESCRIPTION
NOTE: This PR is being merged into a long running branch. Once this new feature has had all work merged into this branch, it will be ready to open up as a PR against the original author's github repo. More details here: https://github.com/AniTrend/retrofit-graphql/issues/9

This PR ties all of the previous work together, to get this GraphQL library to work with externally defined fragments. 

I found one issue that caused fragments which were referenced multiple times, to then be applied to the final query multiple times (which the server doesn't like). 
So I fixed that and updated the tests.

I updated all of this library's sample app queries to use the externally defined fragments. Hopefully they (Anitrend) doesn't mind. If you run the sample app, you'll see that everything is working as expected.

The only thing left is to update their documentation.

![Screen Shot 2019-05-31 at 4 36 17 PM](https://user-images.githubusercontent.com/2137515/58738338-99e00400-83c2-11e9-8ddb-4b78777101cc.png)
