### PR TITLE
Update README.MD to explain fragment locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ First, you'll need .graphql files for saving your GraphQL queries, fragments, an
 
 With respect to fragments, you have two options. Either place them inside your query file after the query definition or put them in their own file under the `assets/graphql/Example/Fragment/` folder. You may also use a mixture of the two if you wish. Note, only define one fragment per file and make sure the name of the fragment matches the filename. For example:
 
-A query that lives in: `assets/graphql/Example/Query/Trending.graphql`. It references two fragments (`RepositoryFragment` and `UserFragment`) that were not defined with the query in the same file. They fragment definitions live elsewhere.
+In the example file `assets/graphql/Example/Query/Trending.graphql` two fragments (`RepositoryFragment` and `UserFragment`) are referenced but not defined in the same file.
 ```
 query Trending($type: FeedType!, $offset: Int, $limit: Int) {
   feed(type: $type, offset: $offset, limit: $limit) {

--- a/README.md
+++ b/README.md
@@ -31,9 +31,49 @@ For a detailed example please clone the project and look at the included sample 
 
 ### The Basics
 
-Firstly you'll need some to save your GraphQL queries and mutations into .graphql files, You can use this tool to generate your Insomnia workspaces into directories and files [insomnia-graphql-generator](https://github.com/AniTrend/insomnia-graphql-generator) and place these files into your assets folder as shown below:
+Firstly you'll need some to save your GraphQL queries, fragments, and mutations into .graphql files. You can use this tool to generate your Insomnia workspaces into directories and files [insomnia-graphql-generator](https://github.com/AniTrend/insomnia-graphql-generator) and place these files into your assets folder as shown below:
 
 <img src="./images/screenshots/assets_files.png" width=250 />
+
+With respect to fragments, you have two options as to where you can place them. You can place them inside your query file, after the query definition. Or, you can put your fragments in their own file under the `assets/graphql/Example/Fragment/` folder. You can also use a mix of the two if you wish. Only define one fragment per file, and make sure the name of the fragment matches the filename. For example:
+
+A query that lives in: `assets/graphql/Example/Query/Trending.graphql`. It references two fragments (`RepositoryFragment` and `UserFragment`) that were not defined with the query in the same file. They fragment definitions live elsewhere.
+```
+query Trending($type: FeedType!, $offset: Int, $limit: Int) {
+  feed(type: $type, offset: $offset, limit: $limit) {
+    id
+    hotScore
+    repository {
+      ...RepositoryFragment
+    }
+    postedBy {
+      ...UserFragment
+    }
+  }
+}
+```
+
+The `RepositoryFragment` lives in `assets/graphql/Example/Fragment/RepositoryFragment.graphql`. It happens to reference a `UserFragment` as well, which is defined in its own file. It is fine for fragments to reference other fragments:
+```
+fragment RepositoryFragment on Repository {
+  name
+  full_name
+  owner {
+    ...UserFragment
+  }
+  stargazers_count
+}
+```
+
+The `UserFragment` lives in `assets/graphql/Example/Fragment/UserFragment.graphql`:
+```
+fragment UserFragment on User {
+  login
+  avatar_url
+  html_url
+}
+```
+
 
 - __Add the JitPack repository to your build file__
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ First, you'll need .graphql files for saving your GraphQL queries, fragments, an
 
 With respect to fragments, you have two options. Either place them inside your query file after the query definition, or put them in their own file under the `assets/graphql/Example/Fragment/` folder. You may also use a mixture of the two if you wish. Note, only define one fragment per file and make sure the name of the fragment matches the filename. Here's an example:
 
-In the file `assets/graphql/Example/Query/Trending.graphql` two fragments (`RepositoryFragment` and `UserFragment`) are referenced but not defined in the same file.
+In the file `assets/graphql/Example/Query/Trending.graphql`, two fragments (`RepositoryFragment` and `UserFragment`) are referenced but not defined in the same file.
 ```
 query Trending($type: FeedType!, $offset: Int, $limit: Int) {
   feed(type: $type, offset: $offset, limit: $limit) {

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For a detailed example please clone the project and look at the included sample 
 
 ### The Basics
 
-Firstly you'll need somewhere to save your GraphQL queries, fragments, and mutations into .graphql files. You can use this tool to generate your Insomnia workspaces into directories and files [insomnia-graphql-generator](https://github.com/AniTrend/insomnia-graphql-generator) and place these files into your assets folder as shown below:
+First, you'll need .graphql files for saving your GraphQL queries, fragments, and mutations. You can use this tool to generate your Insomnia workspaces into directories and files [insomnia-graphql-generator](https://github.com/AniTrend/insomnia-graphql-generator), placing them into your assets folder as shown below:
 
 <img src="./images/screenshots/assets_files.png" width=250 />
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ First, you'll need .graphql files for saving your GraphQL queries, fragments, an
 
 With respect to fragments, you have two options. Either place them inside your query file after the query definition or put them in their own file under the `assets/graphql/Example/Fragment/` folder. You may also use a mixture of the two if you wish. Note, only define one fragment per file and make sure the name of the fragment matches the filename. For example:
 
-In the example file `assets/graphql/Example/Query/Trending.graphql` two fragments (`RepositoryFragment` and `UserFragment`) are referenced but not defined in the same file.
+In the file `assets/graphql/Example/Query/Trending.graphql` two fragments (`RepositoryFragment` and `UserFragment`) are referenced but not defined in the same file.
 ```
 query Trending($type: FeedType!, $offset: Int, $limit: Int) {
   feed(type: $type, offset: $offset, limit: $limit) {

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For a detailed example please clone the project and look at the included sample 
 
 ### The Basics
 
-Firstly you'll need some to save your GraphQL queries, fragments, and mutations into .graphql files. You can use this tool to generate your Insomnia workspaces into directories and files [insomnia-graphql-generator](https://github.com/AniTrend/insomnia-graphql-generator) and place these files into your assets folder as shown below:
+Firstly you'll need somewhere to save your GraphQL queries, fragments, and mutations into .graphql files. You can use this tool to generate your Insomnia workspaces into directories and files [insomnia-graphql-generator](https://github.com/AniTrend/insomnia-graphql-generator) and place these files into your assets folder as shown below:
 
 <img src="./images/screenshots/assets_files.png" width=250 />
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ First, you'll need .graphql files for saving your GraphQL queries, fragments, an
 
 <img src="./images/screenshots/assets_files.png" width=250 />
 
-With respect to fragments, you have two options as to where you can place them. You can place them inside your query file after the query definition. Or, you can put your fragments in their own file under the `assets/graphql/Example/Fragment/` folder. You can also use a mix of the two if you wish. Only define one fragment per file, and make sure the name of the fragment matches the filename. For example:
+With respect to fragments, you have two options. Either place them inside your query file after the query definition or put them in their own file under the `assets/graphql/Example/Fragment/` folder. You may also use a mixture of the two if you wish. Note, only define one fragment per file and make sure the name of the fragment matches the filename. For example:
 
 A query that lives in: `assets/graphql/Example/Query/Trending.graphql`. It references two fragments (`RepositoryFragment` and `UserFragment`) that were not defined with the query in the same file. They fragment definitions live elsewhere.
 ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ query Trending($type: FeedType!, $offset: Int, $limit: Int) {
 }
 ```
 
-The `RepositoryFragment` lives in `assets/graphql/Example/Fragment/RepositoryFragment.graphql`. It happens to reference a `UserFragment` as well, which is defined in its own file. It is fine for fragments to reference other fragments:
+The `RepositoryFragment` lives in `assets/graphql/Example/Fragment/RepositoryFragment.graphql`. It happens to reference `UserFragment` which is also defined in its own file. Note, it is fine for fragments to reference other fragments.
 ```
 fragment RepositoryFragment on Repository {
   name

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ First, you'll need .graphql files for saving your GraphQL queries, fragments, an
 
 <img src="./images/screenshots/assets_files.png" width=250 />
 
-With respect to fragments, you have two options. Either place them inside your query file after the query definition or put them in their own file under the `assets/graphql/Example/Fragment/` folder. You may also use a mixture of the two if you wish. Note, only define one fragment per file and make sure the name of the fragment matches the filename. For example:
+With respect to fragments, you have two options. Either place them inside your query file after the query definition, or put them in their own file under the `assets/graphql/Example/Fragment/` folder. You may also use a mixture of the two if you wish. Note, only define one fragment per file and make sure the name of the fragment matches the filename. Here's an example:
 
 In the file `assets/graphql/Example/Query/Trending.graphql` two fragments (`RepositoryFragment` and `UserFragment`) are referenced but not defined in the same file.
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Firstly you'll need somewhere to save your GraphQL queries, fragments, and mutat
 
 <img src="./images/screenshots/assets_files.png" width=250 />
 
-With respect to fragments, you have two options as to where you can place them. You can place them inside your query file, after the query definition. Or, you can put your fragments in their own file under the `assets/graphql/Example/Fragment/` folder. You can also use a mix of the two if you wish. Only define one fragment per file, and make sure the name of the fragment matches the filename. For example:
+With respect to fragments, you have two options as to where you can place them. You can place them inside your query file after the query definition. Or, you can put your fragments in their own file under the `assets/graphql/Example/Fragment/` folder. You can also use a mix of the two if you wish. Only define one fragment per file, and make sure the name of the fragment matches the filename. For example:
 
 A query that lives in: `assets/graphql/Example/Query/Trending.graphql`. It references two fragments (`RepositoryFragment` and `UserFragment`) that were not defined with the query in the same file. They fragment definitions live elsewhere.
 ```


### PR DESCRIPTION
This PR finalizes the new feature we are contributing by updating the README.md documentation. It now explains that fragments can live either with the query, or in their own file, or a mix.

Unless I think of anything else, we should be ready to open a PR against the Anitrend repo to contribute this work!