### PR TITLE
Update external fragment support for all GraphQL operations

### DIFF
--- a/library/src/main/java/io/github/wax911/library/annotation/processor/GraphProcessor.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/GraphProcessor.kt
@@ -91,7 +91,7 @@ class GraphProcessor private constructor(
     @Synchronized
     private fun patchQueries() {
         _graphFiles.entries
-            .filter { GraphRegexUtil.containsAQuery(it.value) }
+            .filter { GraphRegexUtil.containsAnOperation(it.value) }
             .forEach {
                 val patch = fragmentPatcher.includeMissingFragments(it.key, it.value, _graphFiles)
                 if (patch.isNotEmpty()) {

--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentPatcher.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentPatcher.kt
@@ -3,9 +3,10 @@ package io.github.wax911.library.annotation.processor.fragment
 import android.util.Log
 
 /**
- * This class will return a String containing fragment definitions. This String can be appended to a query in order to
- * have all referenced fragments fully defined, before sending it to the server. This allows a query (for example) to
- * reference fragments, but have the definition of those fragments live outside of the query file.
+ * This class will return a String containing fragment definitions. This String can then be appended to a GraphQL
+ * operation in order to have all referenced fragments fully defined, before sending it to the server. This allows a
+ * GraphQL operation to reference fragments, but have the definition of those fragments live outside of the file that
+ * the operation lives in.
  *
  * This class also properly handles recursion. This means fragments can have references to other fragments, and it will
  * do its best to resolve everything correctly.

--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/GraphRegexUtil.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/GraphRegexUtil.kt
@@ -9,10 +9,10 @@ object GraphRegexUtil {
     // Allowed GraphQL names characters are documented here: https://graphql.github.io/graphql-spec/draft/#sec-Names
     // We want to find all occurrences of "...SomeFragment". And the only piece we care about extracting is the
     // name of the fragment ("SomeFragment")
-    private const val REGEX_FRAGMENT_NAME = "[_A-Za-z][_0-9A-Za-z]*"
-    private const val REGEX_FRAGMENT_REFERENCE = "\\.\\.\\.(\\s+)?($REGEX_FRAGMENT_NAME)"
-    private const val REGEX_FRAGMENT_DEFINITION = "fragment\\s{1,}([_A-Za-z][_0-9A-Za-z]*)\\s{1,}on"
-    private const val REGEX_QUERY_DEFINITION = "query\\s{1,}([_A-Za-z][_0-9A-Za-z]*)"
+    private const val REGEX_VALID_NAME = "[_A-Za-z][_0-9A-Za-z]*"
+    private const val REGEX_FRAGMENT_REFERENCE = "\\.\\.\\.(\\s+)?($REGEX_VALID_NAME)"
+    private const val REGEX_FRAGMENT_DEFINITION = "fragment\\s{1,}($REGEX_VALID_NAME)\\s{1,}on"
+    private const val REGEX_OPERATION_DEFINITION = "(query|mutation|subscription)\\s+($REGEX_VALID_NAME)"
     // The fragment name will be found in group 2 of the reference regex match result.
     private const val GROUP_FRAGMENT_REFERENCE = 2
     // The fragment name will be found in group 1 of the definition regex match result.
@@ -37,10 +37,11 @@ object GraphRegexUtil {
     }
 
     /**
-     * Returns whether or not a query can be found in some GraphQL String.
+     * Returns whether or not a valid GraphQL operation (query, mutation, or subscription) can be found in some GraphQL
+     * String.
      */
-    fun containsAQuery(graphqlContent: String): Boolean {
-        return REGEX_QUERY_DEFINITION.toRegex(regexOptions).containsMatchIn(graphqlContent)
+    fun containsAnOperation(graphqlContent: String): Boolean {
+        return (REGEX_OPERATION_DEFINITION.toRegex(regexOptions).containsMatchIn(graphqlContent))
     }
 
     /**

--- a/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/FragmentPatcherTest.kt
+++ b/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/FragmentPatcherTest.kt
@@ -12,7 +12,7 @@ class FragmentPatcherTest {
     private val mockFragmentAnalyzer = mockk<FragmentAnalyzer>()
 
     private val graphFile = "SomeQuery.graphql"
-    private val graphContent = "%s: actual content doesn't matter for tests in this class"
+    private val graphContent = "%s: actual content of this string doesn't matter for tests in this class"
     private val fragmentA = "fragmentA"
     private val fragmentB = "fragmentB"
     private val fragmentC = "fragmentC"

--- a/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/Operation.kt
+++ b/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/Operation.kt
@@ -1,0 +1,11 @@
+package io.github.wax911.library.annotation.processor.fragment
+
+data class Operation(val typeStr: String, val nameStr: String) {
+    companion object {
+        fun enumeration() = listOf(
+            Operation("query", "Query"),
+            Operation("mutation", "Mutation"),
+            Operation("subscription", "Subscription")
+        )
+    }
+}

--- a/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/RegexFragmentAnalyzerTest.kt
+++ b/library/src/test/kotlin/io/github/wax911/library/annotation/processor/fragment/RegexFragmentAnalyzerTest.kt
@@ -2,8 +2,15 @@ package io.github.wax911.library.annotation.processor.fragment
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
-class RegexFragmentAnalyzerTest {
+/**
+ * The test methods in this class will run three times using the JUnit parameterized test mechanism. Whether we are
+ * dealing with an operation of type: "query", "mutation", or "subscription", the tests should pass.
+ */
+@RunWith(Parameterized::class)
+class RegexFragmentAnalyzerTest(private val operation: Operation) {
     private val fragmentNameTemplate = "someObject%sFragment"
     private val typeTemplate = "Object%s"
     private val fragmentA = createFragmentName("A")
@@ -24,8 +31,8 @@ class RegexFragmentAnalyzerTest {
     """.trimIndent()
 
     private val queryTemplate = """
-        query SomeQuery {
-          someQuery {
+        %s Some%s {
+          some%s {
             objectA {
               ...$fragmentA
             }
@@ -44,7 +51,7 @@ class RegexFragmentAnalyzerTest {
     private val subj = RegexFragmentAnalyzer()
 
     @Test
-    fun `Given a query with all fragments defined, When analyze fragments, Then analysis matches expectation`() {
+    fun `Given an operation with all fragments defined, When analyze fragments, Then analysis matches expectation`() {
         val expected = setOf(
             FragmentAnalysis(fragmentA, true),
             FragmentAnalysis(fragmentB, true),
@@ -63,7 +70,7 @@ class RegexFragmentAnalyzerTest {
     }
 
     @Test
-    fun `Given a query with 1 of 3 fragments defined, When analyze fragments, Then analysis matches expectation`() {
+    fun `Given an operation with 1 of 3 fragments defined, When analyze fragments, Then analysis matches expectation`() {
         val expected = setOf(
             FragmentAnalysis(fragmentA, true),
             FragmentAnalysis(fragmentB, false),
@@ -78,7 +85,7 @@ class RegexFragmentAnalyzerTest {
     }
 
     @Test
-    fun `Given a query with no fragments defined, When analyze fragments, Then analysis matches expectation`() {
+    fun `Given an operation with no fragments defined, When analyze fragments, Then analysis matches expectation`() {
         val expected = setOf(
             FragmentAnalysis(fragmentA, false),
             FragmentAnalysis(fragmentB, false),
@@ -89,7 +96,7 @@ class RegexFragmentAnalyzerTest {
     }
 
     @Test
-    fun `Given a query with fragments within fragments, When analyze fragments, Then analysis matches expectation`() {
+    fun `Given an operation with fragments within fragments, When analyze fragments, Then analysis matches expectation`() {
         val expected = setOf(
             FragmentAnalysis(fragmentA, true),
             FragmentAnalysis(fragmentB, false),
@@ -106,8 +113,7 @@ class RegexFragmentAnalyzerTest {
     }
 
     private fun createQuery(definedFragments: String = ""): String {
-        println(queryTemplate.format(definedFragments))
-        return queryTemplate.format(definedFragments)
+        return queryTemplate.format(operation.typeStr, operation.nameStr, operation.nameStr, definedFragments)
     }
 
     private fun createFragment(name: String, type: String, innerFragmentRef: String = ""): String {
@@ -117,4 +123,10 @@ class RegexFragmentAnalyzerTest {
     private fun createFragmentName(letter: String) = fragmentNameTemplate.format(letter)
 
     private fun createType(letter: String) = typeTemplate.format(letter)
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun operation() = Operation.enumeration()
+    }
 }


### PR DESCRIPTION
This PR enhances our "externalized fragment" support that we provided to AniTrend.

I noticed an issue reported in the AniTrend repo that was related to the work we had contributed. Details here: https://github.com/AniTrend/retrofit-graphql/issues/17

The issue, it seems, is that the "externalized fragment" support was not working for any GraphQL operations besides "query". The other types of operations are "mutation" and "subscription".

The fix was rather simple; just update the regex we use. All of the existing tests we had should also just work, but they all define "query" operations for their test data. So I used JUnit's parameterized tests to run each test three times for each operation type.

Jira story for this: https://ibotta.atlassian.net/browse/DI-5504